### PR TITLE
Fix middleware class deprecation warning

### DIFF
--- a/lib/route_downcaser/railtie.rb
+++ b/lib/route_downcaser/railtie.rb
@@ -1,7 +1,7 @@
 module RouteDowncaser
   class Railtie < Rails::Railtie
     initializer "add_downcase_route_middleware" do |app|
-      app.config.middleware.use 'RouteDowncaser::DowncaseRouteMiddleware'
+      app.config.middleware.use RouteDowncaser::DowncaseRouteMiddleware
     end
   end
 end


### PR DESCRIPTION
Rails needs an actual class reference instead of just strings, this change removes the following warning:

```
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "RouteDowncaser::DowncaseRouteMiddleware" => RouteDowncaser::DowncaseRouteMiddleware
```
