### PR TITLE
Relaxed dependency on ActiveSupport

### DIFF
--- a/route_downcaser.gemspec
+++ b/route_downcaser.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
-  s.add_runtime_dependency "activesupport", [">= 3.2", "< 5.1"]
+  s.add_runtime_dependency "activesupport", ">= 3.2"
 end


### PR DESCRIPTION
ActiveSupport version < 5.1 requirement removed. Everything works, tests pass.