### PR TITLE
Allow for ? in querystrings

### DIFF
--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -68,7 +68,7 @@ module RouteDowncaser
     end
 
     def querystring(uri)
-      uri_items(uri).last
+      uri_items(uri).drop(1).join('?')
     end
 
     def has_querystring?(uri)

--- a/test/route_downcaser_test.rb
+++ b/test/route_downcaser_test.rb
@@ -34,6 +34,12 @@ class RouteDowncaserTest < ActiveSupport::TestCase
       assert_equal("hello/world?FOO=BAR", @app.env['REQUEST_URI'])
     end
 
+    test "REQUEST_URI querystring parameters can contain ?" do
+      callenv = { 'REQUEST_URI' => "HELLO/WORLD?FOO=BAR?BAZ=BING", 'REQUEST_METHOD' => "GET" }
+      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
+      assert_equal("hello/world?FOO=BAR?BAZ=BING", @app.env['REQUEST_URI'])
+    end
+
     test "entire PATH_INFO is downcased" do
       callenv = { 'PATH_INFO' => "HELLO/WORLD", 'REQUEST_METHOD' => "GET" }
       RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)


### PR DESCRIPTION
Before when the url would get rewritten part of it would be removed.

For example: www.example.com?redirect=www.example.com?foo=bar would be
rewritten as www.example.com?foo=bar.