### PR TITLE
Ensure we can redirect multibyte URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fixed bug where redirecting multibyte URLs would result in a `Rack::Lint::LintError` (Issue #29).
+
 * Don't lose parts of the querystring when it contains multiple questionmarks. Thanks, {rmeritz}[https://github.com/rmeritz].
 
 ## 1.2.1

--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -80,7 +80,7 @@ module RouteDowncaser
     end
 
     def redirect_header(uri)
-      [301, {'Location' => uri, 'Content-Type' => 'text/html'}, []]
+      [301, {'Location' => uri.to_s, 'Content-Type' => 'text/html'}, []]
     end
   end
 

--- a/test/route_downcaser_test.rb
+++ b/test/route_downcaser_test.rb
@@ -161,5 +161,35 @@ class RouteDowncaserTest < ActiveSupport::TestCase
     end
   end
 
+  class MultibyteRedirectTests < ActiveSupport::TestCase
+    setup do
+      @app = MyMockApp.new
+      RouteDowncaser.configuration do |config|
+        config.redirect = true
+        config.exclude_patterns = nil
+      end
+    end
 
+    test 'it redirects Multibyte REQUEST_URI' do
+      callenv = { 'REQUEST_URI' => 'ШУРШАЩАЯ ЗМЕЯ', 'REQUEST_METHOD' => 'GET' }
+      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
+      result = RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
+      status, headers = *result
+
+      assert_equal 301, status
+      assert_equal 'шуршащая змея', headers['Location']
+      assert_instance_of String, headers['Location'], 'Headers must be strings'
+    end
+
+    test 'it redirects Multibyte PATH_INFO' do
+      callenv = { 'PATH_INFO' => 'ВЕЛОСИПЕД', 'REQUEST_METHOD' => 'GET' }
+      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
+      result = RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
+      status, headers = *result
+
+      assert_equal 301, status
+      assert_equal 'велосипед', headers['Location']
+      assert_instance_of String, headers['Location'], 'Headers must be strings'
+    end
+  end
 end


### PR DESCRIPTION
Closes #29

HTTP Headers must be set as Strings. Without it we get errors like

> Rack::Lint::LintError: a header value must be a String, but the value of
> 'Location' is a ActiveSupport::Multibyte::Chars