### PR TITLE
Explicitly require the required methods from ActiveSupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Sinatra users no longer need to `require "active_support"` manually to prevent `NoMethodError`s.
+
 * Dropped support for Rails 4. Going forward we're targetting Rails 5.x (and 6.x). Rails 5 deprecates a few configuration options that we need access to. If you still need support for Rails 4.x, version 1.2.2 of route_downcaser should work just fine.
 
 * Dropped support for Ruby versions older than 2.4 (ie 2.2 and 2.3). They are EOL and should not be used in production.

--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -1,3 +1,4 @@
+require "active_support/core_ext/object/blank"
 require "active_support/core_ext/string/multibyte"
 
 module RouteDowncaser

--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/string/multibyte"
+
 module RouteDowncaser
   class DowncaseRouteMiddleware
     def initialize(app)


### PR DESCRIPTION
Closes #35 

When Rails isn't present we never actually required the ActiveSupport methods that we need, so things would fail on ie Sinatra.

So far it seems the only methods we use are

1. `String#mb_chars`
2. `Object#present?`
