### PR TITLE
add rubocop as a development dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ matrix:
     - rvm: 3.0.0
       env: "RAILS_VERSION=5.2.4.4"
 
-script:
-  - bundle exec rake build
-  - bundle exec rubocop
-
 addons:
   code_climate:
     repo_token: 9b174f785a3f1ad8986730da28c2756320f0413067e7e06bad278280f47743fd

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ matrix:
     - rvm: 3.0.0
       env: "RAILS_VERSION=5.2.4.4"
 
+script:
+  - bundle exec rake build
+  - bundle exec rubocop
+
 addons:
   code_climate:
     repo_token: 9b174f785a3f1ad8986730da28c2756320f0413067e7e06bad278280f47743fd

--- a/route_downcaser.gemspec
+++ b/route_downcaser.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib}/**/*'] + ['MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
   s.add_runtime_dependency 'activesupport', '>= 3.2'
+  s.add_development_dependency 'rubocop', '= 1.11.0'
 end


### PR DESCRIPTION
Seems like a shame to have defined rubocop config (and implemented rubocop changes) and not enforce it.

I've pinned the version of rubocop to the latest version to prevent arbitrary correctness changes.