### PR TITLE
Remove therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'rails', rails
 ###############################################
 # The following gems are also needed to test within the Rails env
 gem 'jquery-rails'
-gem 'therubyracer'
 gem 'turbolinks'
 ###############################################
 


### PR DESCRIPTION
It looks like we don't need this dependency any longer. Removing it to avoid dealing with installing libv8 and whatnot.