### PR TITLE
Replace therubyracer with mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'rails', rails
 ###############################################
 # The following gems are also needed to test within the Rails env
 gem 'jquery-rails'
-gem 'therubyracer'
+gem 'mini_racer'
 gem 'turbolinks'
 ###############################################
 


### PR DESCRIPTION
The therubyracer gem is no longer maintained and the suggestion is to just use mini_racer instead.

See https://github.com/rubyjs/therubyracer/issues/462