### PR TITLE
Only process PATH_INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [BREAKING] We now rely only on rack-spec-compliant values to investigate the URLs. This should improve compatibility with different application servers. In particular, this means we now ignore the `REQUEST_URI` value and rely solely on `PATH_INFO`. If your application relies on `REQUEST_URI` being downcased, this could be a breaking change.
+
 * Added support for URLs with non-ASCII characters in them. In other words, your application shouldn't get stuck in a an infinite redirect loop when a request contains non-ASCII characters that can be downcased.
 
 * Added Ruby 3.0, 3.1, 3.2 to the test matrix.

--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -13,26 +13,21 @@ module RouteDowncaser
     end
 
     def _call(env)
-      request_uri = env["REQUEST_URI"]
       path_info = env["PATH_INFO"]
 
-      # Don't touch anything, if uri/path is part of exclude_patterns
-      return @app.call(env) if excluded?([request_uri, path_info])
+      # Don't touch anything, if path is part of exclude_patterns
+      return @app.call(env) if excluded?([path_info])
 
-      # Downcase request_uri and/or path_info if applicable
-      request_uri = downcased_uri(request_uri)
+      # Downcase path_info if applicable
       path_info = downcased_uri(path_info)
 
-      # If redirect configured, then return redirect request,
-      # if either request_uri or path_info has changed
+      # If redirect configured, then return redirect request, if either
+      # path_info has changed
       if RouteDowncaser.redirect && env["REQUEST_METHOD"] == "GET"
-        return redirect_header(request_uri) if request_uri.present? && request_uri != env["REQUEST_URI"]
-
         return redirect_header(path_info) if path_info.present? && path_info != env["PATH_INFO"]
       end
 
       env["PATH_INFO"] = path_info.to_s if path_info
-      env["REQUEST_URI"] = request_uri.to_s if request_uri
 
       # Default just move to next chain in Rack callstack
       # calling with downcased uri if needed

--- a/test/route_downcaser_test.rb
+++ b/test/route_downcaser_test.rb
@@ -23,24 +23,6 @@ class RouteDowncaserTest < ActiveSupport::TestCase
       end
     end
 
-    test "REQUEST_URI path-part is downcased" do
-      callenv = {"REQUEST_URI" => "HELLO/WORLD", "REQUEST_METHOD" => "GET"}
-      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      assert_equal("hello/world", @app.env["REQUEST_URI"])
-    end
-
-    test "REQUEST_URI querystring parameters are not touched" do
-      callenv = {"REQUEST_URI" => "HELLO/WORLD?FOO=BAR", "REQUEST_METHOD" => "GET"}
-      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      assert_equal("hello/world?FOO=BAR", @app.env["REQUEST_URI"])
-    end
-
-    test "REQUEST_URI querystring parameters can contain ?" do
-      callenv = {"REQUEST_URI" => "HELLO/WORLD?FOO=BAR?BAZ=BING", "REQUEST_METHOD" => "GET"}
-      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      assert_equal("hello/world?FOO=BAR?BAZ=BING", @app.env["REQUEST_URI"])
-    end
-
     test "entire PATH_INFO is downcased" do
       callenv = {"PATH_INFO" => "HELLO/WORLD", "REQUEST_METHOD" => "GET"}
       RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
@@ -68,18 +50,6 @@ class RouteDowncaserTest < ActiveSupport::TestCase
       RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
       assert_equal("/ASSETS/IMAges/SpaceCat.jpeg", @app.env["PATH_INFO"])
     end
-
-    test "when REQUEST_URI is found in exclude_patterns, do nothing" do
-      callenv = {"REQUEST_URI" => "ASSETS/IMAges/SpaceCat.jpeg", "REQUEST_METHOD" => "GET"}
-      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      assert_equal("ASSETS/IMAges/SpaceCat.jpeg", @app.env["REQUEST_URI"])
-    end
-
-    test "the call environment should always be returned" do
-      callenv = {"REQUEST_URI" => "ASSETS/IMAges/SpaceCat.jpeg", "REQUEST_METHOD" => "GET"}
-      retval = RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      assert_equal(callenv, retval)
-    end
   end
 
   class RedirectTrueTests < ActiveSupport::TestCase
@@ -89,14 +59,6 @@ class RouteDowncaserTest < ActiveSupport::TestCase
         config.redirect = true
         config.exclude_patterns = nil
       end
-    end
-
-    test "when redirect is true it redirects REQUEST_URI" do
-      callenv = {"REQUEST_URI" => "HELLO/WORLD", "REQUEST_METHOD" => "GET"}
-      assert_equal(
-        [301, {"Location" => "hello/world", "Content-Type" => "text/html"}, []],
-        RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      )
     end
 
     test "when redirect is true it redirects PATH_INFO" do
@@ -117,12 +79,6 @@ class RouteDowncaserTest < ActiveSupport::TestCase
       end
     end
 
-    test "when redirect is true it does not redirect, if REQUEST_URI match exclude patterns" do
-      callenv = {"REQUEST_URI" => "fonts/Icons.woff", "REQUEST_METHOD" => "GET"}
-      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      assert_equal("fonts/Icons.woff", @app.env["REQUEST_URI"])
-    end
-
     test "when redirect is true it does not redirect, if PATH_INFO match exclude patterns" do
       callenv = {"PATH_INFO" => "/fonts/Icons.woff", "REQUEST_METHOD" => "GET"}
       RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
@@ -139,12 +95,6 @@ class RouteDowncaserTest < ActiveSupport::TestCase
       end
     end
 
-    test "Multibyte REQUEST_URI path-part is downcased" do
-      callenv = {"REQUEST_URI" => URI.encode_www_form_component("ШУРШАЩАЯ ЗМЕЯ"), "REQUEST_METHOD" => "GET"}
-      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      assert_equal(URI.encode_www_form_component("шуршащая змея"), @app.env["REQUEST_URI"])
-    end
-
     test "Multibyte PATH_INFO is downcased" do
       callenv = {"PATH_INFO" => "/" + URI.encode_www_form_component("ВЕЛОСИПЕД"), "REQUEST_METHOD" => "GET"}
       RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
@@ -159,17 +109,6 @@ class RouteDowncaserTest < ActiveSupport::TestCase
         config.redirect = true
         config.exclude_patterns = nil
       end
-    end
-
-    test "it redirects Multibyte REQUEST_URI" do
-      callenv = {"REQUEST_URI" => URI.encode_www_form_component("ШУРШАЩАЯ ЗМЕЯ"), "REQUEST_METHOD" => "GET"}
-      RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      result = RouteDowncaser::DowncaseRouteMiddleware.new(@app).call(callenv)
-      status, headers = *result
-
-      assert_equal 301, status
-      assert_equal URI.encode_www_form_component("шуршащая змея"), headers["Location"]
-      assert_instance_of String, headers["Location"], "Headers must be strings"
     end
 
     test "it redirects Multibyte PATH_INFO" do


### PR DESCRIPTION
REQUEST_URI env is not actually part of the [Rack spec](https://github.com/rack/rack/blob/main/SPEC.rdoc) and is not needed for supporting case-insensitive routing? This stems from the CGI standard which defines PATH_INFO but not REQUEST_URI.

We should be able to function perfectly fine with just the PATH_INFO. Only tests that failed after removing REQUEST_URI handling were the ones that explicitly tested REQUEST_URI handling.

While REQUEST_URI might be an informal convention, it isn't necessarily handled the same way by all application servers. Fx Webrick includes the host name in REQUEST_URI whereas Puma does not, leading to confusion and issues like #34 on Webrick.

Closes #34, #45