### PR TITLE
Fix path with tilde

### DIFF
--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -20,6 +20,7 @@ module RouteDowncaser
 
       # Downcase path_info if applicable
       path_info = downcased_uri(path_info)
+      path_info = path_info.gsub('%7E', '~') if path_info
 
       # If redirect configured, then return redirect request, if either
       # path_info has changed

--- a/test/integration/route_middleware_test.rb
+++ b/test/integration/route_middleware_test.rb
@@ -58,6 +58,15 @@ class RouteMiddlewareTest < ActionDispatch::IntegrationTest
     assert_equal "/пиво", URI.decode_www_form_component(response.location)
   end
 
+  test "Can downcase path with tilde correctly" do
+    RouteDowncaser.configuration do |config|
+      config.redirect = true
+    end
+    get "/~Test~~test"
+    assert_equal 301, response.status
+    assert_equal "/~test~~test", URI.decode_www_form_component(response.location)
+  end
+
   test "Can downcase longer unicode paths correctly" do
     RouteDowncaser.configuration do |config|
       config.redirect = true


### PR DESCRIPTION
This PR fix path contains a symbol of tilde (`~`)