### PR TITLE
Remove depracated multi-byte methods

### DIFF
--- a/lib/route_downcaser/downcase_route_middleware.rb
+++ b/lib/route_downcaser/downcase_route_middleware.rb
@@ -57,9 +57,9 @@ module RouteDowncaser
     def downcased_uri(uri)
       return nil unless uri.present?
       if has_querystring?(uri)
-        "#{path(uri).mb_chars.downcase}?#{querystring(uri)}"
+        "#{path(uri).downcase}?#{querystring(uri)}"
       else
-        path(uri).mb_chars.downcase
+        path(uri).downcase
       end
     end
 


### PR DESCRIPTION
This commit removes calls to #mb_chars which is no longer needed in modern Ruby and Rails. Additionally, Active Support 8.2 will remove the method breaking the gem.

Removes the following:

```
DEPRECATION WARNING: ActiveSupport::Multibyte::Chars is deprecated and will be removed in Rails 8.2. Use normal string methods instead.
````

This is supported natively as of Ruby 2.4. 

> NOTE: Ruby 2.4 and later support native Unicode case mappings:

https://api.rubyonrails.org/v8.1.0/classes/String.html#method-i-mb_chars