### PR TITLE
Drop support for Rails versions before 8.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,13 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails-version: ['5.2.8.1', '6.1.7.6', '7.0.8', '7.1.2', '8.0.0', '8.1.0', 'main']
+        rails-version: ['8.0.0', '8.1.0','main']
         ruby-version: ['3.2', '3.3', '3.4']
         exclude:
-          - rails-version: '5.2.8.1'
-            ruby-version: '3.3'
-          - rails-version: '5.2.8.1'
-            ruby-version: '3.4'
           - rails-version: 'main'
             ruby-version: '3.2'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2.1.0
+## Unreleased
 
 * [BREAKING] Dropped support for Ruby versions before 3.2.
+
+* [BREAKING] Dropped support for Rails versions before 8.0. As of August 9, 2026 Rails 7.2 is EOL.
+
+## 2.1.0
 
 * We no longer change tilde characters (`~`) in URLs to their percentage-encoding *(`%7E`) as part of the downcasing process. Thanks {Yegorov}[https://github.com/Yegorov]!
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ rails = case rails_version
 when "main"
   {github: "rails/rails", branch: "main"}
 when "default"
-  ">= 6.1.0"
+  ">= 8.0.0"
 else
   "~> #{rails_version}"
 end

--- a/README.rdoc
+++ b/README.rdoc
@@ -6,13 +6,9 @@ This gem hooks into the Rack middleware of Rails. This way all paths are downcas
 
 == Requirements
 
-This gem is tested with 5.2.x, 6.x, 7.x. It reportedly also works with Sinatra, although I do not use Sinatra myself. Sinatra test-cases will be most welcome.
+This gem is tested with Rails 8.x. It reportedly also works with Sinatra, although I do not use Sinatra myself. Sinatra test-cases will be most welcome.
 
-It has previously worked - and I presume still works - in Rails 5.0.x and 5.1.x.
-
-If you want this functionality in a Rails 2.x-3.0 application, please refer to {this blog post}[http://gehling.dk/2010/02/how-to-make-rails-routing-case-insensitive]. If you need it for Rails 3.1.x or 4.x version 1.2.2 should serve you just fine.
-
-<b>Note:</b> from version 1.2.0, route_downcaser depends on ActiveSupport 3.2 or later. This was necessary to enable support for multibyte characters.
+It has previously worked - and I presume still works - in Rails 5.x, 6.x, 7.x, but that's considered unsupported as of v3.0.
 
 == Installing
 

--- a/route_downcaser.gemspec
+++ b/route_downcaser.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
     "parameters are not changed in any way."
 
   s.files = Dir["{lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
-  s.add_runtime_dependency "activesupport", ">= 3.2"
+  s.add_runtime_dependency "activesupport", ">= 8.0"
   s.add_development_dependency "standard"
 end


### PR DESCRIPTION
As of August 9, 2026 Rails 7.2 is EOL as per Rails' maintenance policy at https://rubyonrails.org/maintenance.

That leaves 8.0.x and 8.1.x as the supported releases.