### PR TITLE
Drop support for Ruby versions before 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,30 +23,12 @@ jobs:
     strategy:
       matrix:
         rails-version: ['5.2.8.1', '6.1.7.6', '7.0.8', '7.1.2', '8.0.0', '8.1.0', 'main']
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['3.2', '3.3', '3.4']
         exclude:
           - rails-version: '5.2.8.1'
             ruby-version: '3.3'
           - rails-version: '5.2.8.1'
             ruby-version: '3.4'
-          - rails-version: '8.0.0'
-            ruby-version: '2.7'
-          - rails-version: '8.0.0'
-            ruby-version: '3.0'
-          - rails-version: '8.0.0'
-            ruby-version: '3.1'
-          - rails-version: '8.1.0'
-            ruby-version: '2.7'
-          - rails-version: '8.1.0'
-            ruby-version: '3.0'
-          - rails-version: '8.1.0'
-            ruby-version: '3.1'
-          - rails-version: 'main'
-            ruby-version: '2.7'
-          - rails-version: 'main'
-            ruby-version: '3.0'
-          - rails-version: 'main'
-            ruby-version: '3.1'
           - rails-version: 'main'
             ruby-version: '3.2'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.1.0
 
+* [BREAKING] Dropped support for Ruby versions before 3.2.
+
 * We no longer change tilde characters (`~`) in URLs to their percentage-encoding *(`%7E`) as part of the downcasing process. Thanks {Yegorov}[https://github.com/Yegorov]!
 
 * Added Rails 8.0 and 8.1 support (no changes).


### PR DESCRIPTION
3.1.x and earlier are now EOL as per Rubys maintenance policy. See https://www.ruby-lang.org/en/downloads/.