### PR TITLE
Add gems missing in Ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,6 +39,8 @@ jobs:
             ruby-version: '3.0'
           - rails-version: 'main'
             ruby-version: '3.1'
+          - rails-version: 'main'
+            ruby-version: '3.2'
 
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,12 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "base64"
-gem "bigdecimal"
-gem "drb"
-gem "mutex_m"
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")
+  gem "base64"
+  gem "bigdecimal"
+  gem "drb"
+  gem "mutex_m"
+end
 
 ###############################################
 # Enable testing of multiple rails versions

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,11 @@ source "http://rubygems.org"
 
 gemspec
 
+gem "base64"
+gem "bigdecimal"
+gem "drb"
+gem "mutex_m"
+
 ###############################################
 # Enable testing of multiple rails versions
 rails_version = ENV["RAILS_VERSION"] || "default"


### PR DESCRIPTION
We're getting the following deprecation warnings running bundle exec:

> ~/bin/ruby: warning: The environment variable RUBY_GC_HEAP_INIT_SLOTS is deprecated; use environment variables RUBY_GC_HEAP_%d_INIT_SLOTS instead
> ~/lib/ruby/gems/3.3.0/gems/railties-6.1.3.1/lib/rails/application.rb:7: warning: base64 was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
> You can add base64 to your Gemfile or gemspec to silence this warning.
> ~/lib/ruby/gems/3.3.0/gems/activesupport-6.1.3.1/lib/active_support/dependencies.rb:299: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
> You can add bigdecimal to your Gemfile or gemspec to silence this warning.
> Also please contact the author of activesupport-6.1.3.1 to request adding bigdecimal into its gemspec.
> ~/lib/ruby/gems/3.3.0/gems/activesupport-6.1.3.1/lib/active_support/dependencies.rb:299: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
> You can add mutex_m to your Gemfile or gemspec to silence this warning.
> Also please contact the author of activesupport-6.1.3.1 to request adding mutex_m into its gemspec.
> ~/lib/ruby/gems/3.3.0/gems/activesupport-6.1.3.1/lib/active_support/core_ext/class/subclasses.rb:30: warning: method redefined; discarding old subclasses
> ~/lib/ruby/gems/3.3.0/gems/activesupport-6.1.3.1/lib/active_support/dependencies.rb:299: warning: drb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
> You can add drb to your Gemfile or gemspec to silence this warning.
> Also please contact the author of activesupport-6.1.3.1 to request adding drb into its gemspec.
> ~/lib/ruby/gems/3.3.0/gems/thor-1.1.0/lib/thor/error.rb:105: warning: constant DidYouMean::SPELL_CHECKERS is deprecated
> Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name =>
> spell_checker)' has been deprecated. Please call
> `DidYouMean.correct_error(error_name, spell_checker)' instead.